### PR TITLE
Document Engine 0.5.0 release

### DIFF
--- a/docs/releases/0.5.0-release-notes.md
+++ b/docs/releases/0.5.0-release-notes.md
@@ -1,0 +1,76 @@
+# Ichiloto Engine 0.5.0
+
+Released: 2026-08-21
+
+`0.5.0` turns Ichiloto Engine into a complete runtime target for story-driven terminal RPGs.
+
+The release adds first-class cinematics and summons, resumable story events, richer world state, typed combat and progression contracts, and a versioned save format designed to survive changes in both the engine and the game built on it. It also hardens terminal output so fields, menus, modals, and battle overlays remain stable across partial writes and redraws.
+
+## Highlights
+
+### Cinematics and summons as runtime systems
+
+Cinematics and summons are now engine-owned assets rather than project-specific playback code. A game can define cast members, camera routes, waits, movement, dialogue, audio, parallel lanes, checkpoints, skip behavior, and finalizers through typed runtime definitions.
+
+Summons use the same foundation with dedicated playback sessions, tracks, keyframes, cues, party wielders, integrity checks, and an in-game Summons menu. Editor previews and live gameplay therefore execute the same runtime contracts.
+
+### Resumable story execution
+
+Story events can pause for presentation, continue later, and preserve their position through save and load. The event interpreter now coordinates typed commands, conditional cues, cooperative lanes, choices, transfers, shops, chests, scripted actions, and cinematic triggers without losing the surrounding field state.
+
+Parallel event work fails as one operation: when a lane cannot continue, its sibling operations are cancelled instead of leaving a partially completed scene behind.
+
+### Durable save compatibility
+
+Save data now uses versioned envelopes with separate engine-schema and project-content versions. Sequential migrations upgrade older engine data, while project manifests can declare renamed identifiers, removed content, aliases, and tombstones.
+
+Legacy saves are detected explicitly. Incompatible saves fail with actionable diagnostics instead of being loaded against content whose identities no longer match.
+
+### Unified combat, progression, and identity
+
+Actors, classes, inventory, equipment, skills, enemies, states, knowledge records, statistics, and progression now share stable identity contracts. Typed combat resolution centralizes damage, elements, states, rewards, escape policy, and permanent growth so battles and reporting tools observe the same rules as gameplay.
+
+Quest progress, achievements, shops, notifications, summon state, and equipment policy remain connected to the persistent game model rather than maintaining separate approximations.
+
+### Richer maps and world state
+
+Maps now carry regions, transitions, map-local NPC state, weighted encounters, background music, collision rules, scrolling cameras, and persistent event state. Field transitions and dialogue presentation preserve the active scene correctly, including when a modal overlaps the HUD or the player crosses a camera boundary.
+
+### More reliable terminal rendering
+
+Console output now handles partial writes, cursor placement, wrapping, selection highlights, modal restoration, field HUD recomposition, and battle pause overlays as complete frames. This reduces the terminal artifacts that appeared when a write was interrupted or a smaller overlay restored the content beneath it.
+
+## Upgrade Notes
+
+Engine 0.5 requires PHP 8.4 and Symfony Console 8.
+
+Update a project with Composer:
+
+```bash
+composer require ichiloto/engine:^0.5 --with-all-dependencies
+```
+
+Projects created before versioned saves should use Console 0.5 to generate and validate their compatibility manifest:
+
+```bash
+ichiloto upgrade
+ichiloto validate
+```
+
+Commit the generated `assets/Data/save-compatibility.php` file with the project. Its identifiers become part of the project's long-term save contract, so renames and removals should be represented there instead of silently reusing old identifiers.
+
+The development suite now uses Pest 5.1. Extensions around the suite should be updated to versions compatible with Pest 5 and PHPUnit 13.
+
+## Validation
+
+This release is covered by regression tests for:
+
+- cinematic definition, playback, checkpoints, skipping, finalizers, and map triggers
+- summon definitions, party assignments, playback sessions, menus, and integrity checks
+- resumable and parallel event execution, including failure cancellation
+- versioned save envelopes, engine migrations, project aliases, tombstones, and legacy detection
+- typed combat resolution, elements, states, rewards, escape policy, and progression
+- map transitions, NPC state, encounters, audio, collision, regions, and camera scrolling
+- partial console writes, cursor placement, modal restoration, wrapping, and selection highlighting
+
+The release gate completes with 710 passing tests, one intentional skip, 2,666 assertions, a clean Composer validation, and no PHPStan errors.

--- a/docs/releases/0.5.0-release-notes.md
+++ b/docs/releases/0.5.0-release-notes.md
@@ -42,7 +42,7 @@ Console output now handles partial writes, cursor placement, wrapping, selection
 
 ## Upgrade Notes
 
-Engine 0.5 requires PHP 8.4 and Symfony Console 8.
+Engine 0.5 requires PHP 8.4.1 and Symfony Console 8.
 
 Update a project with Composer:
 


### PR DESCRIPTION
## Summary

- add immutable Engine 0.5.0 release notes at docs/releases/0.5.0-release-notes.md
- document runtime highlights, upgrade steps, and release validation
- retain one file per release for GitHub release copy and later website publication

## Validation

- Composer validation passes
- Pest: 710 passed, 1 skipped, 2,666 assertions
- PHPStan passes